### PR TITLE
XDSM fix: only run pyxdsm when connections exist in the model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 0.3.1, Unreleased, TBD
+- Bugfix: only run pyxdsm when there are connections in the system
 - Added *_out/ to .gitignore to avoid clutter
 - Added methanol production base class
 - Added steam methane reforming methanol production technology

--- a/h2integrate/core/h2integrate_model.py
+++ b/h2integrate/core/h2integrate_model.py
@@ -630,7 +630,7 @@ class H2IntegrateModel:
                 self.plant.linear_solver = om.DirectSolver()
                 break
 
-        if pyxdsm is not None:
+        if (pyxdsm is not None) and (len(technology_interconnections) > 0):
             create_xdsm_from_config(self.plant_config)
 
     def create_driver_model(self):


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELETE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code highlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# XDSM fix: only run pyxdsm when connections exist in the model
Several tests were failing locally because pyxdsm was trying to create diagrams of systems without connections. I added a check to the default call to run pydxsm so that pyxdsm will only be run with the default call if there are connections in the system.

<!-- Describe your feature here. Please include any code snippets or examples in this section. -->


## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [-] Documentation
  - [-] Docstrings are up-to-date
  - [-] Related `docs/` files are up-to-date, or added when necessary
  - [-] Documentation has been rebuilt successfully
  - [-] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->


## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `h2integrate/core/h2integrate_model.py`
  - `connect_technologies`: pyxdsm should only be run if there are connections in the system.
 
## Additional supporting information

<!--Add any other context about the problem here.-->


## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->


<!--
__ For NREL use __
Release checklist:
- [ ] Update the version in h2integrate/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NREL/H2Integrate repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
