### PR TITLE
Making pipe and cable substance-agnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Updated option to pass variables in technology interconnections to allow for different variable names from source to destination in the format `[source_tech, dest_tech, (source_tech_variable, dest_tech_variable)]`
 - Added `simulation` section under `plant_config['plant']` that has information such as number of timesteps in the simulation, time step interval in seconds, simulation start time, and time zone.
 - Added `"custom_electrolyzer_cost"` model, an electrolyzer cost model that allows for user-defined capex and opex values
+- Made `pipe` and `cable` substance-agnostic rather than hard-coded for `hydrogen` and `electricity`
 
 ## 0.3.0 [May 2 2025]
 

--- a/examples/05_wind_h2_opt/driver_config.yaml
+++ b/examples/05_wind_h2_opt/driver_config.yaml
@@ -7,11 +7,11 @@ general:
 driver:
   optimization:
     flag: True
+    solver: COBYLA
     tol: 0.1
     catol: 10000
     max_iter: 100
-    solver: COBYLA
-    rhobeg: 30
+    rhobeg: 10
     debug_print: True
 
 design_variables:
@@ -35,4 +35,4 @@ objective:
 recorder:
   flag: True
   file: "wind_h2_opt.sql"
-  includes: ["LCOH"]
+  includes: ["*"]

--- a/h2integrate/core/h2integrate_model.py
+++ b/h2integrate/core/h2integrate_model.py
@@ -464,6 +464,7 @@ class H2IntegrateModel:
 
                 # Create the transport object
                 connection_component = self.supported_models[transport_type]()
+                connection_component.transport_item = transport_item
 
                 # Add the connection component to the model
                 self.plant.add_subsystem(connection_name, connection_component)

--- a/h2integrate/core/h2integrate_model.py
+++ b/h2integrate/core/h2integrate_model.py
@@ -463,8 +463,9 @@ class H2IntegrateModel:
                 connection_name = f"{source_tech}_to_{dest_tech}_{transport_type}"
 
                 # Create the transport object
-                connection_component = self.supported_models[transport_type]()
-                connection_component.transport_item = transport_item
+                connection_component = self.supported_models[transport_type](
+                    transport_item=transport_item
+                )
 
                 # Add the connection component to the model
                 self.plant.add_subsystem(connection_name, connection_component)

--- a/h2integrate/transporters/cable.py
+++ b/h2integrate/transporters/cable.py
@@ -1,4 +1,7 @@
 import openmdao.api as om
+from attrs import field
+
+from h2integrate.core.validators import contains
 
 
 class CablePerformanceModel(om.ExplicitComponent):
@@ -6,21 +9,25 @@ class CablePerformanceModel(om.ExplicitComponent):
     Pass-through cable with no losses.
     """
 
+    transport_item: str = field(validator=contains(["electricity"]))
+
     def setup(self):
+        self.input_name = self.transport_item + "_in"
+        self.output_name = self.transport_item + "_out"
         self.add_input(
-            "electricity_in",
+            self.input_name,
             val=0.0,
             shape_by_conn=True,
-            copy_shape="electricity_out",
+            copy_shape=self.output_name,
             units="kW",
         )
         self.add_output(
-            "electricity_out",
+            self.output_name,
             val=0.0,
             shape_by_conn=True,
-            copy_shape="electricity_in",
+            copy_shape=self.input_name,
             units="kW",
         )
 
     def compute(self, inputs, outputs):
-        outputs["electricity_out"] = inputs["electricity_in"]
+        outputs[self.output_name] = inputs[self.input_name]

--- a/h2integrate/transporters/cable.py
+++ b/h2integrate/transporters/cable.py
@@ -1,7 +1,4 @@
 import openmdao.api as om
-from attrs import field
-
-from h2integrate.core.validators import contains
 
 
 class CablePerformanceModel(om.ExplicitComponent):
@@ -9,11 +6,12 @@ class CablePerformanceModel(om.ExplicitComponent):
     Pass-through cable with no losses.
     """
 
-    transport_item: str = field(validator=contains(["electricity"]))
+    def initialize(self):
+        self.options.declare("transport_item", values=["electricity"])
 
     def setup(self):
-        self.input_name = self.transport_item + "_in"
-        self.output_name = self.transport_item + "_out"
+        self.input_name = self.options["transport_item"] + "_in"
+        self.output_name = self.options["transport_item"] + "_out"
         self.add_input(
             self.input_name,
             val=0.0,

--- a/h2integrate/transporters/pipe.py
+++ b/h2integrate/transporters/pipe.py
@@ -1,7 +1,4 @@
 import openmdao.api as om
-from attrs import field
-
-from h2integrate.core.validators import contains
 
 
 class PipePerformanceModel(om.ExplicitComponent):
@@ -9,13 +6,14 @@ class PipePerformanceModel(om.ExplicitComponent):
     Pass-through pipe with no losses.
     """
 
-    transport_item: str = field(
-        validator=contains(["hydrogen", "co2", "methanol", "ammonia", "nitrogen"])
-    )
+    def initialize(self):
+        self.options.declare(
+            "transport_item", values=["hydrogen", "co2", "methanol", "ammonia", "nitrogen"]
+        )
 
     def setup(self):
-        self.input_name = self.transport_item + "_in"
-        self.output_name = self.transport_item + "_out"
+        self.input_name = self.options["transport_item"] + "_in"
+        self.output_name = self.options["transport_item"] + "_out"
         self.add_input(
             self.input_name,
             val=0.0,

--- a/h2integrate/transporters/pipe.py
+++ b/h2integrate/transporters/pipe.py
@@ -1,4 +1,7 @@
 import openmdao.api as om
+from attrs import field
+
+from h2integrate.core.validators import contains
 
 
 class PipePerformanceModel(om.ExplicitComponent):
@@ -6,21 +9,27 @@ class PipePerformanceModel(om.ExplicitComponent):
     Pass-through pipe with no losses.
     """
 
+    transport_item: str = field(
+        validator=contains(["hydrogen", "co2", "methanol", "ammonia", "nitrogen"])
+    )
+
     def setup(self):
+        self.input_name = self.transport_item + "_in"
+        self.output_name = self.transport_item + "_out"
         self.add_input(
-            "hydrogen_in",
+            self.input_name,
             val=0.0,
             shape_by_conn=True,
-            copy_shape="hydrogen_out",
+            copy_shape=self.output_name,
             units="kg/s",
         )
         self.add_output(
-            "hydrogen_out",
+            self.output_name,
             val=0.0,
             shape_by_conn=True,
-            copy_shape="hydrogen_in",
+            copy_shape=self.input_name,
             units="kg/s",
         )
 
     def compute(self, inputs, outputs):
-        outputs["hydrogen_out"] = inputs["hydrogen_in"]
+        outputs[self.output_name] = inputs[self.input_name]

--- a/h2integrate/transporters/test/test_pipe.py
+++ b/h2integrate/transporters/test/test_pipe.py
@@ -1,0 +1,40 @@
+import pytest
+import openmdao.api as om
+from pytest import approx
+
+from h2integrate.transporters.pipe import PipePerformanceModel
+
+
+def test_pipe_with_hydrogen():
+    """Test the pipe transport with hydrogen as transport_item."""
+
+    # Create the pipe component with hydrogen as transport item
+    pipe = PipePerformanceModel(transport_item="hydrogen")
+
+    # Create OpenMDAO problem and add the component
+    prob = om.Problem()
+    prob.model.add_subsystem("pipe", pipe, promotes=["*"])
+
+    # Add independent variable component for input
+    ivc = om.IndepVarComp()
+    ivc.add_output("hydrogen_in", val=10.0, units="kg/s")
+    prob.model.add_subsystem("ivc", ivc, promotes=["*"])
+
+    # Setup and run the model
+    prob.setup()
+    prob.set_val("hydrogen_in", 10.0, units="kg/s")
+    prob.run_model()
+
+    # Check that output equals input (pass-through pipe with no losses)
+    hydrogen_in = prob.get_val("hydrogen_in", units="kg/s")
+    hydrogen_out = prob.get_val("hydrogen_out", units="kg/s")
+
+    assert hydrogen_out == approx(hydrogen_in, rel=1e-10)
+    assert hydrogen_out == approx(10.0, rel=1e-10)
+
+
+def test_pipe_with_invalid_transport_item():
+    """Test that pipe raises an error with invalid transport_item."""
+    with pytest.raises(ValueError) as excinfo:
+        PipePerformanceModel(transport_item="invalid_item")
+    assert "Value ('invalid_item')" in str(excinfo.value)


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELETE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code highlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Making pipe and cable substance-agnostic

As it is, the `pipe` and `cable` can only carry one substance each, `hydrogen` and `electricity` respectively, and this is hard-coded into the transporters. Since these are meant to be general lossless transporters they should be able to carry other substances which I call `transport_item`, and I need them to for the purposes of linking other tech modules - in particular CO2 capture and methanol production.

## Type of Contribution
<!-- Check all that apply to help reviewers understand your contribution -->
- [X] Feature Enhancement
  - [ ] New Technology Model
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):

## General PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [x] Examples have been updated (if applicable)
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] Added tests for new functionality or bug fixes
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Impacted areas of the software

- `h2integrate/core/h2integrate_model.py`: Added one line which passes a new `transport_item` parameter to `pipe` and `cable`
- `h2integrate/transporters/pipe.py`: Allows a `pipe` to carry any of a defined list of substances, not just `hydrogen`
- `h2integrate/transporters/cable.py`: Allows a `cable` to carry any of a defined list of substances, not just `electricity`, although `electricity` is currently the only defined substance. In the future I imagine we may want to further delineate ac/dc and voltage levels.

## Additional supporting information

This was originally wrapped up in PR #239 , but I realized it should be split off into its own PR since it is a change to a core function that affects other tech. It is needed for that PR to carry CO2 from ocean capture to methanol production.


<!--
__ For NREL use __
Release checklist:
- [ ] Update the version in h2integrate/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NREL/H2Integrate repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
