### PR TITLE
Updated/Fixed SQL Recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.1 [Unreleased, TBD]
+- Updated setting up recorder in `PoseOptimization`
+
 ## 0.4.0 [October 1, 2025]
 
 This release introduces significant new technology models and framework capabilities for system design and optimization, alongside major refactoring and user experience improvements.

--- a/h2integrate/core/h2integrate_model.py
+++ b/h2integrate/core/h2integrate_model.py
@@ -807,25 +807,22 @@ class H2IntegrateModel:
 
     def create_driver_model(self):
         """
-        Add the driver to the OpenMDAO model.
+        Add the driver to the OpenMDAO model and add recorder.
         """
+
+        myopt = PoseOptimization(self.driver_config)
         if "driver" in self.driver_config:
-            myopt = PoseOptimization(self.driver_config)
             myopt.set_driver(self.prob)
             myopt.set_objective(self.prob)
             myopt.set_design_variables(self.prob)
             myopt.set_constraints(self.prob)
+        # Add a recorder if specified in the driver config
+        if "recorder" in self.driver_config:
+            myopt.set_recorders(self.prob)
 
     def run(self):
         # do model setup based on the driver config
         # might add a recorder, driver, set solver tolerances, etc
-
-        # Add a recorder if specified in the driver config
-        if "recorder" in self.driver_config:
-            recorder_config = self.driver_config["recorder"]
-            recorder = om.SqliteRecorder(recorder_config["file"])
-            self.model.add_recorder(recorder)
-
         self.prob.setup()
 
         self.prob.run_driver()

--- a/h2integrate/core/pose_optimization.py
+++ b/h2integrate/core/pose_optimization.py
@@ -3,6 +3,7 @@ This file is based on the WISDEM file of the same name: https://github.com/WISDE
 and also based off of the H2Integrate file of the same name originally adapted by Jared Thomas.
 """
 
+import re
 import warnings
 from pathlib import Path
 
@@ -431,22 +432,54 @@ class PoseOptimization:
         """
         folder_output = self.config["general"]["folder_output"]
 
+        # Check that the output folder exists and create it if needed
+        if not Path(folder_output).exists():
+            Path.mkdir(folder_output, parents=True)
         # Set recorder on the OpenMDAO driver level using the `optimization_log`
         # filename supplied in the optimization yaml
-        if self.config["recorder"]["flag"]:
-            recorder = om.SqliteRecorder(Path(folder_output) / self.config["recorder"]["file_name"])
-            opt_prob.driver.add_recorder(recorder)
-            opt_prob.add_recorder(recorder)
+        if self.config["recorder"].get("flag", False):
+            overwrite_recorder = self.config["recorder"].get("overwrite_recorder", False)
+            recorder_path = Path(folder_output) / self.config["recorder"]["file"]
 
-            opt_prob.driver.recording_options["excludes"] = ["*_df"]
-            opt_prob.driver.recording_options["record_constraints"] = True
-            opt_prob.driver.recording_options["record_desvars"] = True
-            opt_prob.driver.recording_options["record_objectives"] = True
+            if not overwrite_recorder:
+                # make a unique filename with the same base as self.config["recorder"]["file"]
+                # separate out the filename without the extension
+                file_base = self.config["recorder"]["file"].split(".sql")[0]
+                # get all the files in the output folder that start with file_base
+                existing_files = list(Path(folder_output).glob(f"{file_base}*"))
+                if len(existing_files) > 0:
+                    # if file(s) exist with the same base name, make a new unique filename
 
-            if self.config["recorder"]["includes"]:
-                opt_prob.driver.recording_options["includes"] = self.config["recorder"]["includes"]
+                    # get past numbers that were used to make unique files by matching
+                    # filenames against the file base name followed by a number
+                    past_numbers = [
+                        int(re.findall(f"{file_base}[0-9]+", fname)[0].split(fname)[-1])
+                        for fname in existing_files
+                        if len(re.findall(f"{file_base}[0-9]+", fname)) > 0
+                    ]
 
-        return opt_prob
+                    if len(past_numbers) > 0:
+                        # if multiple files have the same basename followed by a number,
+                        # take the maximum unique number and add one
+                        unique_number = int(max(past_numbers) + 1)
+                        recorder_path = Path(folder_output) / f"{file_base}{unique_number}.sql"
+                    else:
+                        # if no files have the same basename followed by a number,
+                        # but do have the same basename, then add a zero to the file basename
+                        recorder_path = Path(folder_output) / f"{file_base}0.sql"
+
+            recorder = om.SqliteRecorder(recorder_path)
+            opt_prob.model.add_recorder(recorder)
+
+            opt_prob.model.recording_options["record_inputs"] = True
+            opt_prob.model.recording_options["record_outputs"] = True
+            opt_prob.model.recording_options["record_residuals"] = True
+
+            if self.config["recorder"].get("includes", False):
+                opt_prob.model.recording_options["includes"] = self.config["recorder"]["includes"]
+
+            if self.config["recorder"].get("excludes", False):
+                opt_prob.model.recording_options["excludes"] = self.config["recorder"]["excludes"]
 
     def set_restart(self, opt_prob):
         """


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELETE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code highlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Updated/Fixed SQL Recording

<!-- Describe your feature here. Please include any code snippets or examples in this section. -->
If using a recorder (specified in the driver config), the output .sql file did not seem to "listen" to any user-specified recording parameters such as excluding specific data or including specific data. This was because the recorder was being initialized in the `run()` function of `H2IntegrateModel` and this initialization did not include looking at user-input recording options. The `set_recorders()` method in `PoseOptimization` was intended to do this but was never called. 

Some important information about why I made updates the way I did:

When the recorder was made in the `run()` function of `H2IntegrateModel`, it was done so with the line:
```python
recorder = om.SqliteRecorder(recorder_config["file"])
```

this method of creating a recorder (only specifying the filename) resulted in the recorder output files being written to folder that was autocreated by Sqlite and named based off the main run script and was intended to not overwrite any existing outputs. So- if you ran H2Integrate from the script `run_wind_electrolyzer.py`, and have the recorder file named as `wind_h2_opt.sql`, it would save the `wind_h2_opt.sql` file to a folder named `run_wind_electrolyzer` or `run_wind_electrolyzer0` or `run_wind_electrolyzer1` - aka - it made a new folder with added numbers included to not overwrite any existing folders.

The auto-generation of a folder to prevent overwriting sql files does not happen if the folder is specified when creating the recorder as done below:
```python
folder_output = self.config["general"]["folder_output"]
recorder = om.SqliteRecorder(Path(folder_output) / recorder_config["file"])
```

For the recorder file to be output in the folder specified in `driver_config["general"]["folder_output"]` prevents the auto-generated folder naming that happens when just a filename is specified, which means that output files could be overwritten.

This could be considered undesirable, because folks would have to change the filename in the driver config for each optimization they run to prevent overwriting files. But also - maybe people would want a file to be overwritten.

To account for both of these possible cases, I added some functionality into the `set_recorders()` method that:
- checks to see if `driver_config["recorder"]["overwrite_recorder"] = True`, if "overwrite_recorder" is not included, it will assume the result is False. 
- If overwrite recorder is True, it will create the recorder using the filename specified in `driver_config["recorder"]["file"]`
- If overwrite recorder is False (or not input), it will create a unique recorder name (rather than a new folder) with the same base filename with added numbers to prevent overwriting existing output files. For example, output files may be: 

- `wind_h2_opt.sql` (first time running)
- `wind_h2_opt0.sql` (second run)
- `wind_h2_opt1.sql` (third run)
- and so on


## Type of Contribution
<!-- Check all that apply to help reviewers understand your contribution -->
- [x] Feature Enhancement
  - [ ] New Technology Model
- [x] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):

## General PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [ ] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [ ] Documentation
  - [ ] Docstrings are up-to-date
  - [ ] Related `docs/` files are up-to-date, or added when necessary
  - [ ] Documentation has been rebuilt successfully
  - [ ] Examples have been updated (if applicable)
- [ ] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [ ] Added tests for new functionality or bug fixes
- [ ] PR description thoroughly describes the new feature, bug fix, etc.

## New Technology Checklist
<!-- Complete this section only if you checked "New Technology Model" above -->
- [ ] **Performance Model**: Technology performance model has been implemented and follows H2Integrate patterns (if applicable)
- [ ] **Cost Model**: Technology cost model has been implemented (if applicable)
- [ ] **Tests**: Unit tests have been added for the new technology
  - [ ] Performance model tests (if applicable)
  - [ ] Cost model tests (if applicable)
  - [ ] Integration tests with H2Integrate system
- [ ] **Example**: A working example demonstrating the new technology has been created
  - [ ] Example has been tested and runs successfully in `test_all_examples.py`
  - [ ] Example is documented with clear explanations in `examples/README.md`
    - [ ] Input file comments
    - [ ] Run file comments
- [ ] **Documentation**:
  - [ ] Technology documentation page added to `docs/technology_models/`
  - [ ] Technology added to the main technology models list in `docs/technology_models/technology_overview.md`
- [ ] **Integration**: Technology has been properly integrated into H2Integrate
  - [ ] Added to `supported_models.py`
  - [ ] If a new commodity_type is added, update `create_financial_model` in `h2integrate_model.py`
  - [ ] Follows established naming conventions outlined in `docs/developer_guide/coding_guidelines.md`

## Related issues

<!--If one exists, link to a related GitHub Issue.-->


## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->
- `h2integrate/core/pose_optimization.py`: `PoseOptimization`
  - `set_recorders`: Updated to work!
     - create the folder specified in `driver_config['general']['folder_output']` if it doesn't exist
     - updated so recorder is added to the model
     - updated to include setting `excludes` recording options if input in the config
     - other updates mentioned earlier in the PR description.
- `h2integrate/core/h2integrate_model.py`: 
  - `create_driver_model()`: Updated to call `PostOptimization.set_recorders()` if `recorder` is included in the driver config.
  - `run()`: removed code that created a recorder

## Additional supporting information

<!--Add any other context about the problem here.-->


## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->


<!--
__ For NREL use __
Release checklist:
- [ ] Update the version in h2integrate/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NREL/H2Integrate repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
